### PR TITLE
Addition of Tracing crate to logging options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,6 @@ serde_urlencoded = "0"
 signal-hook = "0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tokio-tungstenite = { version = "0", features = ["native-tls"] }
+tracing = "0.1.40"
+tracing-subscriber = "0.3.18"
 url = "2"

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,6 @@ pub struct IllegalArgumentException(String);
 
 impl IllegalArgumentException {
     pub fn new(msg: &str) -> IllegalArgumentException {
-        error!(msg);
         IllegalArgumentException(msg.to_string())
     }
 }
@@ -31,7 +30,6 @@ pub struct IllegalStateException {
 
 impl IllegalStateException {
     pub fn new(msg: &str) -> IllegalStateException {
-        error!(msg);
         IllegalStateException {
             details: msg.to_string(),
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,13 @@
 use std::error::Error;
 use std::fmt;
+use tracing::error;
 
 #[derive(Debug)]
 pub struct IllegalArgumentException(String);
 
 impl IllegalArgumentException {
     pub fn new(msg: &str) -> IllegalArgumentException {
+        error!(msg);
         IllegalArgumentException(msg.to_string())
     }
 }
@@ -29,6 +31,7 @@ pub struct IllegalStateException {
 
 impl IllegalStateException {
     pub fn new(msg: &str) -> IllegalStateException {
+        error!(msg);
         IllegalStateException {
             details: msg.to_string(),
         }

--- a/src/ls_client.rs
+++ b/src/ls_client.rs
@@ -355,8 +355,8 @@ impl LightstreamerClient {
                                     //
                                     "conok" => {
                                         if let Some(session_id) = submessage_fields.get(1).as_deref() {
-                                            self.make_log( Level::INFO, &format!("Session creation confirmed by server: {}", clean_text) );
-                                            self.make_log( Level::INFO, &format!("Session created with ID: {:?}", session_id) );
+                                            self.make_log( Level::DEBUG, &format!("Session creation confirmed by server: {}", clean_text) );
+                                            self.make_log( Level::DEBUG, &format!("Session created with ID: {:?}", session_id) );
                                             //
                                             // Subscribe to the desired items.
                                             //
@@ -443,10 +443,10 @@ impl LightstreamerClient {
                                         // Don't do anything with these notifications for now.
                                     },
                                     "probe" => {
-                                        self.make_log( Level::INFO, &format!("Received probe message from server: {}", clean_text ) );
+                                        self.make_log( Level::DEBUG, &format!("Received probe message from server: {}", clean_text ) );
                                     },
                                     "reqok" => {
-                                        self.make_log( Level::INFO, &format!("Received reqok message from server: '{}'", clean_text ) );
+                                        self.make_log( Level::DEBUG, &format!("Received reqok message from server: '{}'", clean_text ) );
                                     },
                                     //
                                     // Subscription confirmation from server.
@@ -714,7 +714,7 @@ impl LightstreamerClient {
                                         write_stream
                                             .send(Message::Text(format!("create_session\r\n{}\n", encoded_params)))
                                             .await?;
-                                        self.make_log( Level::INFO, &format!("Sent create session request: '{}'", encoded_params) );
+                                        self.make_log( Level::DEBUG, &format!("Sent create session request: '{}'", encoded_params) );
                                     },
                                     unexpected_message => {
                                         return Err(Box::new(std::io::Error::new(
@@ -744,7 +744,7 @@ impl LightstreamerClient {
                             )));
                         },
                         None => {
-                            self.make_log( Level::INFO, "No more messages from server" );
+                            self.make_log( Level::DEBUG, "No more messages from server" );
                             break;
                         },
                     }


### PR DESCRIPTION
Added an enum and method LightstreamClient to allow configuration with logging using the Tracing crate. Minimal implementation, could be expanded further with proper spans.