### PR TITLE
Fixed unsubscribe/resubscribe issue

### DIFF
--- a/src/ls_client.rs
+++ b/src/ls_client.rs
@@ -665,6 +665,26 @@ impl LightstreamerClient {
                                                         }
                                                     }
                                                 }
+                                                value if value.starts_with('{') => {
+                                                    // in this case it is a json payload that we will let the consumer handle. In this case, it is important
+                                                    // to preserve casing for parsing.
+                                                    let original_json = parse_arguments(&submessage).get(3).unwrap_or(&"").split('|').collect::<Vec<&str>>();
+                                                    let mut payload = "";
+                                                    for json in original_json.iter()
+                                                    {
+                                                        if json.is_empty() || json.to_string() == "#"
+                                                        {
+                                                            continue;
+                                                        }
+                                                        
+                                                        payload = json;
+                                                    }
+                                                    
+                                                    if let Some(field_name) = subscription_fields.and_then(|fields| fields.get(field_index)) {
+                                                        field_map.insert(field_name.to_string(), Some(payload.to_string()));
+                                                    }
+                                                    field_index += 1;
+                                                }
                                                 _ => {
                                                     let decoded_value = serde_urlencoded::from_str(value).unwrap_or_else(|_| value.to_string());
                                                     if let Some(field_name) = subscription_fields.and_then(|fields| fields.get(field_index)) {

--- a/src/ls_client.rs
+++ b/src/ls_client.rs
@@ -124,6 +124,16 @@ pub struct LightstreamerClient {
     subscription_receiver: Receiver<SubscriptionRequest>,
 }
 
+/// Retrieve a reference to a subscription with the given `id`
+fn get_subscription_by_id(
+    subscriptions: &Vec<Subscription>,
+    subscription_id: usize,
+) -> Option<&Subscription> {
+    subscriptions
+        .iter()
+        .find(|sub| sub.id == subscription_id)
+}
+
 impl Debug for LightstreamerClient {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("LightstreamerClient")
@@ -526,7 +536,7 @@ impl LightstreamerClient {
                                         // Extract the subscription from the first argument.
                                         //
                                         let subscription_index = arguments.get(1).unwrap_or(&"").parse::<usize>().unwrap_or(0);
-                                        let subscription = match self.get_subscriptions().get(subscription_index-1) {
+                                        let subscription = match get_subscription_by_id(self.get_subscriptions(), subscription_index) {
                                             Some(subscription) => subscription,
                                             None => {
                                                 self.make_log( Level::WARN, &format!("Subscription not found for index: {}", subscription_index) );

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,24 @@
 /// Clean the message from newlines and carriage returns and convert it to lowercase. Also remove all brackets.
 pub fn clean_message(text: &str) -> String {
-    text.replace("\n", "").replace("\r", "").to_lowercase()
+    let mut result = String::new();
+    let mut inside_braces = false;
+
+    for part in text.split_inclusive(&['{', '}']) {
+        if part.starts_with('{') && part.ends_with('}') {
+            // Part is fully inside braces
+            inside_braces = true;
+            result.push_str(part);
+        } else if inside_braces {
+            // We're processing a segment after an opening brace
+            inside_braces = false;
+            result.push_str(&part);
+        } else {
+            // Process the part outside braces
+            result.push_str(&part.replace('\n', "").replace('\r', "").to_lowercase());
+        }
+    }
+
+    result
 }
 
 pub fn parse_arguments(input: &str) -> Vec<&str> {


### PR DESCRIPTION
When we retrieved existing subscriptions we used index instead of the id field in the Subscription struct. This caused streams to fail after one unsubscribe/resubscribe as the indexes got reordered.

With this fix we always retrieve subscription from the array based on the id field.

This pr also enables json payloads in the stream fields by making parsing a little bit more resilient to json characters.