### PR TITLE
Add Makefile and Rust toolchain configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,132 @@
+# Makefile for common tasks in a Rust project
+# Detect current branch
+CURRENT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+ZIP_NAME = strategy_exporter.zip
+
+
+# Default target
+.PHONY: all
+all: test fmt lint build
+
+# Build the project
+.PHONY: build
+build:
+	cargo build
+
+.PHONY: release
+release:
+	cargo build --release
+
+# Run tests
+.PHONY: test
+test:
+	LOGLEVEL=WARN cargo test
+
+
+# Format the code
+.PHONY: fmt
+fmt:
+	cargo +stable fmt --all
+
+# Check formatting
+.PHONY: fmt-check
+fmt-check:
+	cargo +stable fmt --check
+
+# Run Clippy for linting
+.PHONY: lint
+lint:
+	cargo clippy --all-targets --all-features -- -D warnings
+
+
+.PHONY: lint-fix
+lint-fix: 
+	cargo clippy --fix --all-targets --all-features --allow-dirty --allow-staged -- -D warnings
+
+
+# Clean the project
+.PHONY: clean
+clean:
+	cargo clean
+
+# Pre-push checks
+.PHONY: check
+check: test fmt-check lint
+
+# Run the project
+.PHONY: run
+run:
+	cargo run
+
+.PHONY: fix
+fix:
+	cargo fix --allow-staged --allow-dirty
+
+.PHONY: pre-push
+pre-push: fix fmt lint-fix test readme
+
+.PHONY: doc
+doc:
+	cargo doc --open
+	cargo clippy -- -W missing-docs
+
+.PHONY: publish
+publish: readme coverage
+	cargo login ${CARGO_REGISTRY_TOKEN}
+	cargo package
+	cargo publish
+
+.PHONY: coverage
+coverage:
+	export LOGLEVEL=WARN
+	cargo install cargo-tarpaulin
+	mkdir -p coverage
+	cargo tarpaulin --all-features --workspace --timeout 120 --out Xml
+
+.PHONY: coverage-html
+coverage-html:
+	export LOGLEVEL=WARN
+	cargo install cargo-tarpaulin
+	mkdir -p coverage
+	cargo tarpaulin --all-features --workspace --timeout 120 --out Html
+
+.PHONY: open-coverage
+open-coverage:
+	open tarpaulin-report.html
+
+# Rule to show git log
+git-log:
+	@if [ "$(CURRENT_BRANCH)" = "HEAD" ]; then \
+		echo "You are in a detached HEAD state. Please check out a branch."; \
+		exit 1; \
+	fi; \
+	echo "Showing git log for branch $(CURRENT_BRANCH) against main:"; \
+	git log main..$(CURRENT_BRANCH) --pretty=full
+
+.PHONY: create-doc
+create-doc:
+	cargo doc --no-deps --document-private-items
+
+.PHONY: readme
+readme: check-cargo-readme create-doc
+	cargo readme > README.md
+
+.PHONY: check-cargo-readme
+check-cargo-readme:
+	@command -v cargo-readme > /dev/null || (echo "Installing cargo-readme..."; cargo install cargo-readme)
+
+.PHONY: check-spanish
+check-spanish:
+	cd scripts && python3 spanish.py ../src && cd ..
+
+.PHONY: zip
+zip:
+	@echo "Creating $(ZIP_NAME) without any 'target' directories, 'Cargo.lock', and hidden files..."
+	@find . -type f \
+		! -path "*/target/*" \
+		! -path "./.*" \
+		! -name "Cargo.lock" \
+		! -name ".*" \
+		| zip -@ $(ZIP_NAME)
+	@echo "$(ZIP_NAME) created successfully."
+

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
Add Makefile and Rust toolchain configuration

Introduce a Makefile to streamline common Rust project tasks, including building, testing, linting, and publishing. Add a rust-toolchain.toml file to ensure the project uses the stable toolchain by default, promoting consistency across environments.